### PR TITLE
Naprawiony błąd, który powodował podwójne wywołanie interakcji

### DIFF
--- a/Assets/Code/Scripts/Player/Interaction/BasicInteraction.cs
+++ b/Assets/Code/Scripts/Player/Interaction/BasicInteraction.cs
@@ -21,10 +21,13 @@ public class BasicInteraction : NetworkBehaviour, IInteractable
 	}
 	public virtual void Interact()
 	{
-		OnInteraction?.Invoke();
 		if (shouldInteractionBeSyncedOnNet)
 		{
 			TriggerInteractionServerRpc();
+		}
+		else
+		{
+			OnInteraction?.Invoke();
 		}
 	}
 }


### PR DESCRIPTION
Naprawiony błąd, który powodował podwójne wywołanie interakcji przy synchronizacji po sieci.