### PR TITLE
Fixed errors with synchronizing class movement

### DIFF
--- a/Assets/Art/Models/Axeman/Axeman.prefab
+++ b/Assets/Art/Models/Axeman/Axeman.prefab
@@ -1510,12 +1510,14 @@ GameObject:
   - component: {fileID: 404813553918837570}
   - component: {fileID: 2852356331713054065}
   - component: {fileID: 2420949097594639137}
-  - component: {fileID: 8747416996073633658}
   - component: {fileID: 7481337492159048783}
   - component: {fileID: 7047022229735846661}
   - component: {fileID: 7558553426013530316}
   - component: {fileID: 1311777105274411778}
   - component: {fileID: 3731110536014199524}
+  - component: {fileID: 8802472904790824818}
+  - component: {fileID: 5109594017326703602}
+  - component: {fileID: 7205449235754635509}
   m_Layer: 7
   m_Name: Axeman
   m_TagString: Untagged
@@ -1579,7 +1581,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 1953571299
+  GlobalObjectIdHash: 341560619
   InScenePlacedSourceGlobalObjectIdHash: 0
   DeferredDespawnTick: 0
   Ownership: 1
@@ -1696,18 +1698,6 @@ MonoBehaviour:
   className: Axeman
   attackRange: 5
   damage: 50
---- !u!114 &8747416996073633658
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4064567944803448117}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f5ab8454d07461e92856751ea27478e8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &7481337492159048783
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1777,6 +1767,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 008ba0b0c9bc5eaedbd9c1a30d81d622, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ShowTopMostFoldoutHeaderGroup: 1
 --- !u!114 &3731110536014199524
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1790,6 +1781,70 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   turretUpgradeUI: {fileID: 2345384520125782939, guid: f7bd249fc3badfb4d80f15a7f961b534, type: 3}
+--- !u!114 &8802472904790824818
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4064567944803448117}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad8deae8091111f4eb30a56c1f4e0d3e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShowTopMostFoldoutHeaderGroup: 1
+  TransitionStateInfoList: []
+  m_Animator: {fileID: 8251226931184058391}
+--- !u!114 &5109594017326703602
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4064567944803448117}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62703c8fee94ee1908376e740f5e9b96, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShowTopMostFoldoutHeaderGroup: 1
+--- !u!114 &7205449235754635509
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4064567944803448117}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: df2868252ab5c4d1da357e8f11f1b524, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShowTopMostFoldoutHeaderGroup: 1
+  NetworkTransformExpanded: 1
+  AuthorityMode: 1
+  TickSyncChildren: 0
+  UseUnreliableDeltas: 0
+  SyncPositionX: 1
+  SyncPositionY: 1
+  SyncPositionZ: 1
+  SyncRotAngleX: 0
+  SyncRotAngleY: 1
+  SyncRotAngleZ: 0
+  SyncScaleX: 0
+  SyncScaleY: 1
+  SyncScaleZ: 0
+  PositionThreshold: 0.001
+  RotAngleThreshold: 0.01
+  ScaleThreshold: 0.01
+  UseQuaternionSynchronization: 0
+  UseQuaternionCompression: 0
+  UseHalfFloatPrecision: 0
+  InLocalSpace: 0
+  SwitchTransformSpaceWhenParented: 0
+  Interpolate: 1
+  SlerpPosition: 0
 --- !u!1 &4208008471921977874
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Art/Models/Knight/Knight.prefab
+++ b/Assets/Art/Models/Knight/Knight.prefab
@@ -1785,6 +1785,12 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: ad026c1bc08c7252c9078546bc6248f9, type: 3}
       insertIndex: -1
       addedObject: {fileID: -6011953891441880031}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: ad026c1bc08c7252c9078546bc6248f9, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1273110352922761535}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: ad026c1bc08c7252c9078546bc6248f9, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8568776242108040772}
   m_SourcePrefab: {fileID: 100100000, guid: ad026c1bc08c7252c9078546bc6248f9, type: 3}
 --- !u!4 &487679418707082207 stripped
 Transform:
@@ -1921,6 +1927,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62703c8fee94ee1908376e740f5e9b96, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ShowTopMostFoldoutHeaderGroup: 1
 --- !u!114 &122589581372559052
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1933,6 +1940,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 008ba0b0c9bc5eaedbd9c1a30d81d622, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ShowTopMostFoldoutHeaderGroup: 1
 --- !u!114 &-4083557466471801919
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2001,6 +2009,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ShowTopMostFoldoutHeaderGroup: 1
+  currentHP:
+    m_InternalValue: 100
   maxHP: 100
   isDead: 0
   animator: {fileID: 5774944085285544357}
@@ -2017,6 +2027,64 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ShowTopMostFoldoutHeaderGroup: 1
+--- !u!114 &1273110352922761535
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 977076010543325541}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: df2868252ab5c4d1da357e8f11f1b524, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShowTopMostFoldoutHeaderGroup: 1
+  NetworkTransformExpanded: 1
+  AuthorityMode: 1
+  TickSyncChildren: 0
+  UseUnreliableDeltas: 0
+  SyncPositionX: 1
+  SyncPositionY: 1
+  SyncPositionZ: 1
+  SyncRotAngleX: 0
+  SyncRotAngleY: 1
+  SyncRotAngleZ: 0
+  SyncScaleX: 0
+  SyncScaleY: 1
+  SyncScaleZ: 0
+  PositionThreshold: 0.001
+  RotAngleThreshold: 0.01
+  ScaleThreshold: 0.01
+  UseQuaternionSynchronization: 0
+  UseQuaternionCompression: 0
+  UseHalfFloatPrecision: 0
+  InLocalSpace: 0
+  SwitchTransformSpaceWhenParented: 0
+  Interpolate: 1
+  SlerpPosition: 0
+--- !u!114 &8568776242108040772
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 977076010543325541}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad8deae8091111f4eb30a56c1f4e0d3e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShowTopMostFoldoutHeaderGroup: 1
+  TransitionStateInfoList:
+  - IsCrossFadeExit: 0
+    Layer: 0
+    OriginatingState: 229373857
+    DestinationState: 1080829965
+    TransitionDuration: 0.25
+    TriggerNameHash: 1080829965
+    TransitionIndex: 0
+  m_Animator: {fileID: 5774944085285544357}
 --- !u!95 &5774944085285544357 stripped
 Animator:
   m_CorrespondingSourceObject: {fileID: 5866666021909216657, guid: ad026c1bc08c7252c9078546bc6248f9, type: 3}

--- a/Assets/Code/Scripts/Player/PlayerClass/Classes/Knight/KnightController.cs
+++ b/Assets/Code/Scripts/Player/PlayerClass/Classes/Knight/KnightController.cs
@@ -1,12 +1,19 @@
+using System.Globalization;
+using Unity.Multiplayer.Samples.Utilities.ClientAuthority;
+using Unity.Netcode;
 using UnityEngine;
 
-public class KnightController : MonoBehaviour
+public class KnightController : NetworkBehaviour
 {
-    private Animator animator;
+    private ClientNetworkAnimator animator;
 
     void Start()
     {
-        animator = GetComponent<Animator>();
+        if (!IsOwner)
+        {
+            enabled = false;
+        }
+        animator = GetComponent<ClientNetworkAnimator>();
     }
 
     void Update()
@@ -22,7 +29,7 @@ public class KnightController : MonoBehaviour
         float y = Input.GetAxis("Vertical");
 
         // Update movement parameters in the animator
-        animator.SetFloat("Strafe", x);
-        animator.SetFloat("Forward", y);
+        animator.Animator.SetFloat("Strafe", x);
+        animator.Animator.SetFloat("Forward", y);
     }
 }

--- a/Assets/Code/Scripts/Player/PlayerClass/PlayerSpawner.cs
+++ b/Assets/Code/Scripts/Player/PlayerClass/PlayerSpawner.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 // Ten skrypt spawnuje gracza w zależności od jego wyboru klasy.
 // W przypadku dodania nowej klasy, uwzględnij ją w metodzie SpawnPlayer.
-public class PlayerSpawner : MonoBehaviour
+public class PlayerSpawner : NetworkBehaviour
 {
     [SerializeField] private GameObject knightPrefab;
     [SerializeField] private GameObject paladinPrefab;

--- a/Assets/Code/Scripts/SwordAttack/SwordAttack.cs
+++ b/Assets/Code/Scripts/SwordAttack/SwordAttack.cs
@@ -1,19 +1,25 @@
 using UnityEngine;
 using System.Collections;
+using Unity.Multiplayer.Samples.Utilities.ClientAuthority;
+using Unity.Netcode;
 
 // Ten skrypt jest odpowiedzialny za atakowanie przeciwników za pomocą miecza.
 // Dodawaj go do prefabów będących mele postaciami gracza.
 // W Animation Controller musisz użyć animacji "Attack" z triggerem "Attack".
-public class SwordAttack : MonoBehaviour
+public class SwordAttack : NetworkBehaviour
 {
     private int damage;  // Amount of damage dealt by the sword
     private float attackRange;  // Range of the sword attack
-    private Animator animator;
+    private ClientNetworkAnimator networkAnimator;
     private bool isAttacking = false;
 
     void Start()
     {
-        animator = GetComponent<Animator>();
+        if (!IsOwner)
+        {
+            enabled = false;
+        }
+        networkAnimator = GetComponent<ClientNetworkAnimator>();
         PlayerClass playerClass = GetComponent<PlayerClass>();
         if (playerClass != null)
         {
@@ -41,7 +47,7 @@ public class SwordAttack : MonoBehaviour
     void Attack()
     {
         isAttacking = true;
-        animator.CrossFade("Attack", 0f);
+        networkAnimator.Animator.CrossFade("Attack", 0f);
 
         // Detect all colliders in range of the attack
         Collider[] hitColliders = Physics.OverlapSphere(transform.position, attackRange);
@@ -63,7 +69,7 @@ public class SwordAttack : MonoBehaviour
     IEnumerator ResetAttack()
     {
         yield return new WaitForSeconds(0.1f);
-        yield return new WaitForSeconds(animator.GetCurrentAnimatorStateInfo(0).length);
+        yield return new WaitForSeconds(networkAnimator.Animator.GetCurrentAnimatorStateInfo(0).length);
         isAttacking = false;
     }
 

--- a/Assets/DefaultNetworkPrefabs.asset
+++ b/Assets/DefaultNetworkPrefabs.asset
@@ -74,3 +74,8 @@ MonoBehaviour:
     SourcePrefabToOverride: {fileID: 0}
     SourceHashToOverride: 0
     OverridingTargetPrefab: {fileID: 0}
+  - Override: 0
+    Prefab: {fileID: 4064567944803448117, guid: f353a7bdc8c6eb4a4918480caf847fcf, type: 3}
+    SourcePrefabToOverride: {fileID: 0}
+    SourceHashToOverride: 0
+    OverridingTargetPrefab: {fileID: 0}

--- a/Assets/Scenes/Mikolaj.unity
+++ b/Assets/Scenes/Mikolaj.unity
@@ -1481,7 +1481,6 @@ GameObject:
   - component: {fileID: 1635041257}
   - component: {fileID: 1635041256}
   - component: {fileID: 1635041255}
-  - component: {fileID: 1635041258}
   m_Layer: 0
   m_Name: NetworkManager
   m_TagString: Untagged
@@ -1576,20 +1575,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1635041258
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1635041254}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eb23ec795ad0414eaf579d6f0d82ac86, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  knightPrefab: {fileID: 977076010543325541, guid: 720003cc4617f72dd888021a022ac6d7, type: 3}
-  paladinPrefab: {fileID: 4064567944803448117, guid: f353a7bdc8c6eb4a4918480caf847fcf, type: 3}
 --- !u!1 &1636885101
 GameObject:
   m_ObjectHideFlags: 0
@@ -1644,6 +1629,79 @@ MonoBehaviour:
   serverButton: {fileID: 1058961677}
   clientButton: {fileID: 1268767146}
   hostButton: {fileID: 253923872}
+--- !u!1 &1653434026
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1653434028}
+  - component: {fileID: 1653434029}
+  - component: {fileID: 1653434027}
+  m_Layer: 0
+  m_Name: PlayerSpawner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1653434027
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1653434026}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eb23ec795ad0414eaf579d6f0d82ac86, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShowTopMostFoldoutHeaderGroup: 1
+  knightPrefab: {fileID: 977076010543325541, guid: 720003cc4617f72dd888021a022ac6d7, type: 3}
+  paladinPrefab: {fileID: 4064567944803448117, guid: f353a7bdc8c6eb4a4918480caf847fcf, type: 3}
+--- !u!4 &1653434028
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1653434026}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.447421, y: 6.3150578, z: -8.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1653434029
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1653434026}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 303874342
+  InScenePlacedSourceGlobalObjectIdHash: 0
+  DeferredDespawnTick: 0
+  Ownership: 1
+  AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
+  SpawnWithObservers: 1
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
+  SyncOwnerTransformWhenParented: 1
+  AllowOwnerToParent: 0
 --- !u!1 &1785591393
 GameObject:
   m_ObjectHideFlags: 0
@@ -1799,6 +1857,10 @@ PrefabInstance:
     - target: {fileID: 4419481995502041677, guid: f9886c5bc56a1a54fb5e6a1afe241561, type: 3}
       propertyPath: m_Name
       value: TestEnemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 4419481995502041677, guid: f9886c5bc56a1a54fb5e6a1afe241561, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5120360981365344012, guid: f9886c5bc56a1a54fb5e6a1afe241561, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2207,3 +2269,4 @@ SceneRoots:
   - {fileID: 1866084137}
   - {fileID: 690370151}
   - {fileID: 1859249476}
+  - {fileID: 1653434028}

--- a/Assets/Settings/UniversalRenderPipelineGlobalSettings.asset
+++ b/Assets/Settings/UniversalRenderPipelineGlobalSettings.asset
@@ -33,29 +33,29 @@ MonoBehaviour:
   m_Settings:
     m_SettingsList:
       m_List:
-      - rid: 1025954399246090388
-      - rid: 1025954399246090389
+      - rid: 1025954950940197122
+      - rid: 1025954950940197123
       - rid: 6852985685364965378
       - rid: 6852985685364965379
       - rid: 6852985685364965380
       - rid: 6852985685364965381
-      - rid: 1025954399246090390
-      - rid: 1025954399246090391
+      - rid: 1025954950940197124
+      - rid: 1025954950940197125
       - rid: 6852985685364965384
       - rid: 6852985685364965385
-      - rid: 1025954399246090392
-      - rid: 1025954399246090393
-      - rid: 1025954399246090394
-      - rid: 1025954399246090395
-      - rid: 1025954399246090396
+      - rid: 1025954950940197126
+      - rid: 1025954950940197127
+      - rid: 1025954950940197128
+      - rid: 1025954950940197129
+      - rid: 1025954950940197130
       - rid: -2
       - rid: 6852985685364965392
       - rid: -2
       - rid: 6852985685364965394
       - rid: -2
       - rid: 1628416862486528000
-      - rid: 1025954399246090397
-      - rid: 1025954399246090398
+      - rid: 1025954950940197131
+      - rid: 1025954950940197132
       - rid: 886087086018920450
     m_RuntimeSettings:
       m_List:
@@ -106,14 +106,14 @@ MonoBehaviour:
       data:
         m_Version: 0
         m_CoreCopyPS: {fileID: 4800000, guid: 12dc59547ea167a4ab435097dd0f9add, type: 3}
-    - rid: 1025954399246090388
+    - rid: 1025954950940197122
       type: {class: URPShaderStrippingSetting, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
         m_StripUnusedPostProcessingVariants: 1
         m_StripUnusedVariants: 1
         m_StripScreenCoordOverrideVariants: 1
-    - rid: 1025954399246090389
+    - rid: 1025954950940197123
       type: {class: UniversalRenderPipelineEditorShaders, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_AutodeskInteractive: {fileID: 4800000, guid: 0e9d5a909a1f7e84882a534d0d11e49f, type: 3}
@@ -125,7 +125,7 @@ MonoBehaviour:
         m_DefaultSpeedTree7Shader: {fileID: 4800000, guid: 0f4122b9a743b744abe2fb6a0a88868b, type: 3}
         m_DefaultSpeedTree8Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
         m_DefaultSpeedTree9Shader: {fileID: -6465566751694194690, guid: cbd3e1cc4ae141c42a30e33b4d666a61, type: 3}
-    - rid: 1025954399246090390
+    - rid: 1025954950940197124
       type: {class: Renderer2DResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
@@ -140,7 +140,7 @@ MonoBehaviour:
         m_DefaultLitMaterial: {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
         m_DefaultUnlitMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
         m_DefaultMaskMaterial: {fileID: 2100000, guid: 15d0c3709176029428a0da2f8cecf0b5, type: 2}
-    - rid: 1025954399246090391
+    - rid: 1025954950940197125
       type: {class: UniversalRenderPipelineEditorMaterials, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_DefaultMaterial: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
@@ -148,7 +148,7 @@ MonoBehaviour:
         m_DefaultLineMaterial: {fileID: 2100000, guid: e823cd5b5d27c0f4b8256e7c12ee3e6d, type: 2}
         m_DefaultTerrainMaterial: {fileID: 2100000, guid: 594ea882c5a793440b60ff72d896021e, type: 2}
         m_DefaultDecalMaterial: {fileID: 2100000, guid: 31d0dcc6f2dd4e4408d18036a2c93862, type: 2}
-    - rid: 1025954399246090392
+    - rid: 1025954950940197126
       type: {class: GPUResidentDrawerResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.GPUDriven.Runtime}
       data:
         m_Version: 0
@@ -161,13 +161,13 @@ MonoBehaviour:
         m_OcclusionCullingDebugKernels: {fileID: 7200000, guid: b23e766bcf50ca4438ef186b174557df, type: 3}
         m_DebugOcclusionTestPS: {fileID: 4800000, guid: d3f0849180c2d0944bc71060693df100, type: 3}
         m_DebugOccluderPS: {fileID: 4800000, guid: b3c92426a88625841ab15ca6a7917248, type: 3}
-    - rid: 1025954399246090393
+    - rid: 1025954950940197127
       type: {class: STP/RuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_setupCS: {fileID: 7200000, guid: 33be2e9a5506b2843bdb2bdff9cad5e1, type: 3}
         m_preTaaCS: {fileID: 7200000, guid: a679dba8ec4d9ce45884a270b0e22dda, type: 3}
         m_taaCS: {fileID: 7200000, guid: 3923900e2b41b5e47bc25bfdcbcdc9e6, type: 3}
-    - rid: 1025954399246090394
+    - rid: 1025954950940197128
       type: {class: ProbeVolumeBakingResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -180,12 +180,12 @@ MonoBehaviour:
         skyOcclusionRT: {fileID: -5126288278712620388, guid: 5a2a534753fbdb44e96c3c78b5a6999d, type: 3}
         renderingLayerCS: {fileID: -6772857160820960102, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
         renderingLayerRT: {fileID: -5126288278712620388, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
-    - rid: 1025954399246090395
+    - rid: 1025954950940197129
       type: {class: ProbeVolumeGlobalSettings, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
         m_ProbeVolumeDisableStreamingAssets: 0
-    - rid: 1025954399246090396
+    - rid: 1025954950940197130
       type: {class: ProbeVolumeDebugResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -195,14 +195,14 @@ MonoBehaviour:
         probeVolumeOffsetDebugShader: {fileID: 4800000, guid: db8bd7436dc2c5f4c92655307d198381, type: 3}
         probeSamplingDebugMesh: {fileID: -3555484719484374845, guid: 20be25aac4e22ee49a7db76fb3df6de2, type: 3}
         numbersDisplayTex: {fileID: 2800000, guid: 73fe53b428c5b3440b7e87ee830b608a, type: 3}
-    - rid: 1025954399246090397
+    - rid: 1025954950940197131
       type: {class: ProbeVolumeRuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
         probeVolumeBlendStatesCS: {fileID: 7200000, guid: a3f7b8c99de28a94684cb1daebeccf5d, type: 3}
         probeVolumeUploadDataCS: {fileID: 7200000, guid: 0951de5992461754fa73650732c4954c, type: 3}
         probeVolumeUploadDataL2CS: {fileID: 7200000, guid: 6196f34ed825db14b81fb3eb0ea8d931, type: 3}
-    - rid: 1025954399246090398
+    - rid: 1025954950940197132
       type: {class: IncludeAdditionalRPAssets, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_version: 0

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -82,7 +82,7 @@ PlayerSettings:
   androidApplicationEntry: 2
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
-  runInBackground: 0
+  runInBackground: 1
   muteOtherAudioSources: 0
   Prepare IOS For Recording: 0
   Force IOS Speakers When Recording: 0


### PR DESCRIPTION
Naprawiłem problemy z synchronizacją animacji i poruszania się klas. W skrócie:
- do klas trzeba było dodać Client Network Transform
- trzeba było dodać Network animator i zmienić skrypty tak aby z niego korzystały
- skrypt spawnujący klasy gracza miał używać RPC, ale był Monobehaviourem, a nie NetworkBehaviourem więc nie do końca to działało
- zrobiłem osobny obiekt Player Spawner, ponieważ jak się zmieniło ww. skrypt na NetworkBehaviour to nie pozwalało go do NetworkManagera podłączyć
- SwordAttack.cs i KnightController.cs teraz też są NetworkBehaviourami i wyłaczają się jeśli !isOwner
- przy axemanie na razie wywaliłem axeManController bo zobaczyłem że jest identyczny jak knightcontroller, a nie chciałem go modyfikować bez potrzeby

Zmiany można zobaczyć na scenie Mikołaja, bo tam już było skonfigurowane spawnowanie tych różnych klas to tam testowałem zmiany w prefabach